### PR TITLE
[MrBot] Fix malformed SRS markdown tags

### DIFF
--- a/devdoc/com_wrapper_requirements.md
+++ b/devdoc/com_wrapper_requirements.md
@@ -269,12 +269,11 @@ Arguments:
 
 - `...` is made of pairs of `(arg_type, arg_name)` which represent the arguments of the function.
 
-**SRS_COM_WRAPPER_01_020: [** The macro shall generate a wrapper function that looks like:
+**SRS_COM_WRAPPER_01_020: [** The macro shall generate a wrapper function that looks like: **]**
 
 ```c
 return_type STDMETHODCALLTYPE name(implementing_interface* This, arg1_type arg1, arg2_type arg2, ...)
 ```
- **]**
 
 **SRS_COM_WRAPPER_01_021: [** If `This` is NULL, the wrapper shall return without calling the underlying wrapper. **]**
 

--- a/tests/com_wrapper_ut/com_wrapper_ut.c
+++ b/tests/com_wrapper_ut/com_wrapper_ut.c
@@ -549,7 +549,7 @@ TEST_FUNCTION(Release_with_custom_allocator_uses_custom_free)
 
 /* COM_WRAPPER_FUNCTION_WRAPPER */
 
-/* Tests_SRS_COM_WRAPPER_01_020: [ The macro shall generate a wrapper function that looks like: ... ]*/
+/* Tests_SRS_COM_WRAPPER_01_020: [ The macro shall generate a wrapper function that looks like: ]*/
 /* Tests_SRS_COM_WRAPPER_01_021: [ If This is NULL, the wrapper shall return without calling the underlying wrapper. ]*/
 TEST_FUNCTION(COM_WRAPPER_FUNCTION_WRAPPER_generated_wrapper_with_NULL_This_fails)
 {


### PR DESCRIPTION
Pre-emptive fix for malformed SRS tags ahead of c-build-tools srs_format check migration.

Fixes 1 malformed requirement tag in:
- com_wrapper_requirements.md (multi-line tag with code block, closing moved to opening line)