### PR TITLE
Require two human reviewers on bot-authored pull requests

### DIFF
--- a/.github/workflows/two-human-reviewers.yml
+++ b/.github/workflows/two-human-reviewers.yml
@@ -1,0 +1,41 @@
+name: Two human reviewers
+# Requires approvals from two distinct humans on bot-authored pull requests, so a PR the agent opened is
+# not merged on the single approval that would normally be the *second* human to look at a change.
+#
+# The logic lives in c-build-tools so every repository shares one definition; see
+# `.github/workflows/two-human-reviewers.yml` there for why this is a workflow rather than a branch rule,
+# and for the `required-approvals` and `exempt-bots` inputs. This repository does not need to reference
+# c-build-tools any other way: a reusable workflow is fetched by Actions from the ref below, and is not a
+# checkout or a submodule.
+#
+# Keep BOTH triggers below. A called workflow's own triggers are ignored, so these are what re-run the
+# gate; drop `pull_request_review` and it evaluates once at open, finds no approvals, and never re-runs
+# when someone approves - leaving the required check failing until an unrelated push happens to re-trigger
+# it.
+#
+# Do not add a required status check for this until the file is on the default branch, or every open pull
+# request will wait forever on a check that cannot run. Use the `workflow_dispatch` below to produce a
+# first result on pull requests that were already open when it landed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to evaluate.
+        type: string
+        required: true
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# Set here because a called workflow can never hold more permission than its caller.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  two-human-reviewers:
+    uses: Azure/c-build-tools/.github/workflows/two-human-reviewers.yml@master
+    with:
+      pr: ${{ github.event.pull_request.number || inputs.pr }}


### PR DESCRIPTION
Bot-authored pull requests should not merge on a single approval. On a human-authored PR two people have
looked at the change -- the author who wrote and vetted it, and the approver. When the agent opens the PR
that first human is missing, so one approval is the only human judgement applied to it. This restores the
second.

The logic is a reusable workflow in
[Azure/c-build-tools](https://github.com/Azure/c-build-tools/blob/master/.github/workflows/two-human-reviewers.yml),
so every repository shares one definition and this file stays a thin caller. Nothing about it requires this
repository to consume c-build-tools any other way -- Actions fetches a reusable workflow from the pinned
ref, which is neither a checkout nor a submodule.

What it does:

- Runs on every pull request and passes immediately when the author is not a bot, so human-authored PRs are
  unaffected.
- On a bot-authored PR, requires approvals from two distinct humans **who have push access**, on the
  **current** head commit. An approval of an earlier commit does not carry over, because the bot pushes to
  its own PR.
- Keys on the author being a bot rather than on a list of bot names, so a renamed app cannot slip through.

It reports as a status check but is **not** required yet. Making it required before this file is on the
default branch would leave every open PR waiting on a check that cannot run, so that is a separate step
after this merges.