### PR TITLE
[MrBot] Point ARM64 gate at Dpldsv6-v28 pool

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -8,7 +8,7 @@ parameters:
   - name: pool_name_windows_arm64
     displayName: 'Windows ARM64 Pool'
     type: string
-    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v26'
+    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v28'
   - name: pool_name_linux
     displayName: 'Linux Pool'
     type: string

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -28,6 +28,7 @@ jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools
   parameters:
     GBALLOC_LL_TYPE_VALUES: ["PASSTHROUGH", "JEMALLOC"]
+    pool_name_arm64: ${{ parameters.pool_name_windows_arm64 }}
     arm64_max_stage: ALL
 
 - template: /pipeline_templates/run_master_check.yml@c_build_tools


### PR DESCRIPTION
Bump the Windows ARM64 pool default from Dpldsv6-v26 to Dpldsv6-v28.

The v26 ARM64 hosted pool is being retired. v28 is the current image/pool and adds the EnableDefaultServicesUpgrade SF cluster setting required by the gated 'Upgrade SF from master to current' leg. Repointing all consuming repos to v28 is a prerequisite for deleting v26.